### PR TITLE
参加処理完成

### DIFF
--- a/src/api/postEventAttendance.php
+++ b/src/api/postEventAttendance.php
@@ -1,10 +1,12 @@
 <?php
+session_start();
 require('../dbconnect.php');
 header('Content-Type: application/json; charset=UTF-8');
 
 $eventId = $_POST['eventId'];
+$userId = $_SESSION['user_id'];
 
 if ($eventId > 0) {
-  $stmt = $db->prepare('INSERT INTO event_attendance SET event_id=?');
-  $stmt->execute(array($eventId));
+  $stmt = $db->prepare('UPDATE event_attendance SET participation=1, nonparticipation=0, notsubmitted=0 WHERE event_id =? AND user_id =?');
+  $stmt->execute(array($eventId, $userId));
 }

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -52,9 +52,7 @@ async function openModal(eventId) {
           </div>
           <div class="flex mt-5">
             <button class="flex-1 bg-blue-500 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="participateEvent(${eventId})">参加する</button>
-            <!-- 
             <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold">参加しない</button>
-            -->
           </div>
         `
         break;


### PR DESCRIPTION
## 関連イシュー
イベント参加管理 Issue1 誰が参加するかDBに保存する #39
**終了条件**
DBの情報から誰が参加する予定か確認可能

## 検証したこと
・参加するボタンを押した場合、event_attendanceテーブルのparticipationカラムを1に残りのnonparticipationカラムとnotsubmittedカラムを0にするUPDATE処理の作成、動作確認（初期値として、ユーザーは作成時にevent_attendanceテーブル内に全てのイベントに関してparticipation=0、nonparticipation=0、notsubmitted=1としてINSERT済み）
・event_attendanceテーブルでparticipation=1で検索ですることで参加予定者を確認可能

## エビデンス
<img width="1124" alt="image" src="https://user-images.githubusercontent.com/94731753/188807794-cfb8e87d-50f3-4b24-b413-eaab7692a25b.png">
<img width="1139" alt="image" src="https://user-images.githubusercontent.com/94731753/188808039-559de417-fea0-4ffb-a85e-5d2006a49a4c.png">


