### PR TITLE
参加、不参加登録完了

### DIFF
--- a/src/api/postEventAttendance.php
+++ b/src/api/postEventAttendance.php
@@ -3,10 +3,14 @@ session_start();
 require('../dbconnect.php');
 header('Content-Type: application/json; charset=UTF-8');
 
-$eventId = $_POST['eventId'];
+$participationId = $_POST['eventId_0'];
+$nonparticipationId = $_POST['eventId_1'];
 $userId = $_SESSION['user_id'];
 
-if ($eventId > 0) {
+if (!empty($participationId) && empty($nonparticipationId)) {
   $stmt = $db->prepare('UPDATE event_attendance SET participation=1, nonparticipation=0, notsubmitted=0 WHERE event_id =? AND user_id =?');
-  $stmt->execute(array($eventId, $userId));
+  $stmt->execute(array($participationId, $userId));
+}elseif(empty($participationId) && !empty($nonparticipationId)){
+  $stmt = $db->prepare('UPDATE event_attendance SET participation=0, nonparticipation=1, notsubmitted=0 WHERE event_id =? AND user_id =?');
+  $stmt->execute(array($nonparticipationId, $userId));
 }

--- a/src/index.php
+++ b/src/index.php
@@ -14,11 +14,11 @@ $today = date("Y-m-d");
 $user_id = $_SESSION['user_id'];
 if ($_GET["status"]) {
   $conditions = $_GET["conditions"];
-  $stmt = $db->query("SELECT event_attendance.id, events.name, events.start_at, events.end_at,event_attendance.user_id,event_attendance.participation,event_attendance.nonparticipation,event_attendance.notsubmitted, count(event_attendance.id) AS total_participants  FROM event_attendance INNER JOIN events ON event_attendance.event_id=events.id WHERE event_attendance.participation='1' AND events.start_at >= '$today' AND event_attendance.user_id= '$user_id' GROUP BY  event_attendance.id  ORDER BY events.start_at ASC");
+  $stmt = $db->query("SELECT events.id as eventId, event_attendance.id, events.name, events.start_at, events.end_at,event_attendance.user_id,event_attendance.participation,event_attendance.nonparticipation,event_attendance.notsubmitted, count(event_attendance.id) AS total_participants  FROM event_attendance INNER JOIN events ON event_attendance.event_id=events.id WHERE event_attendance.participation='1' AND events.start_at >= '$today' AND event_attendance.user_id= '$user_id' GROUP BY  event_attendance.id  ORDER BY events.start_at ASC");
   $stmt->execute();
   $events = $stmt->fetchAll();
 } else {
-  $stmt = $db->query("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE events.start_at >= '$today' GROUP BY events.id ORDER BY events.start_at ASC");
+  $stmt = $db->query("SELECT events.id as eventId, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE events.start_at >= '$today' GROUP BY events.id ORDER BY events.start_at ASC");
   $stmt->execute();
   $events = $stmt->fetchAll();
 }
@@ -102,7 +102,7 @@ function get_day_of_week($w)
           $end_date = strtotime($event['end_at']);
           $day_of_week = get_day_of_week(date("w", $start_date));
           ?>
-          <div class="modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event-<?php echo $event['id']; ?>">
+          <div class="modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event-<?php echo $event['eventId']; ?>">
             <div>
               <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>
               <p><?php echo date("Y年m月d日（${day_of_week}）", $start_date); ?></p>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -52,7 +52,7 @@ async function openModal(eventId) {
           </div>
           <div class="flex mt-5">
             <button class="flex-1 bg-blue-500 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="participateEvent(${eventId})">参加する</button>
-            <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold">参加しない</button>
+            <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="nonparticipateEvent(${eventId})">参加しない</button>
           </div>
         `
         break;
@@ -92,7 +92,7 @@ function toggleModal() {
 async function participateEvent(eventId) {
   try {
     let formData = new FormData();
-    formData.append('eventId', eventId)
+    formData.append('eventId_0', eventId)
     const url = '/api/postEventAttendance.php'
     await fetch(url, {
       method: 'POST',
@@ -109,6 +109,28 @@ async function participateEvent(eventId) {
     console.log(error)
   }
 }
+
+async function nonparticipateEvent(eventId) {
+  try {
+    let formData = new FormData();
+    formData.append('eventId_1', eventId)
+    const url = '/api/postEventAttendance.php'
+    await fetch(url, {
+      method: 'POST',
+      body: formData
+    }).then((res) => {
+      if(res.status !== 200) {
+        throw new Error("system error");
+      }
+      return res.text();
+    })
+    closeModal()
+    location.reload()
+  } catch (error) {
+    console.log(error)
+  }
+}
+
 
 
 


### PR DESCRIPTION
## 関連イシュー
イベント参加管理 Issue2 誰が参加／不参加の情報をDBに保存する #40
**終了条件**
DBの情報から誰が参加／不参加の予定か確認可能

## 検証したこと
・全て、参加ページそれぞれで参加、不参加処理ができる＋それがテーブルに入っている。（参加であれば、participationカラムが1に不参加であればnonparticipationカラムが1になっている）
・DBでparticipation=1,nonparticipation=1で検索をかけるとそれぞれ参加者、不参加者が確認できる。

## エビデンス
<img width="1141" alt="image" src="https://user-images.githubusercontent.com/94731753/188841161-683f8137-7fe9-4abd-b35d-0e74e550294d.png">
<img width="378" alt="image" src="https://user-images.githubusercontent.com/94731753/188841311-88237c87-9148-4b1d-954f-b7d3174417bc.png">
<img width="381" alt="image" src="https://user-images.githubusercontent.com/94731753/188841418-a2bb73b0-4ed2-4879-9e6a-9ec7abfe17bc.png">

