### PR TITLE
Feature/41

### DIFF
--- a/src/api/getModalInfo.php
+++ b/src/api/getModalInfo.php
@@ -1,6 +1,10 @@
 <?php
 require('../dbconnect.php');
+require('../models/event_attendance.php');
 header('Content-Type: application/json; charset=UTF-8');
+
+session_start();
+$user_id = $_SESSION['user_id'];
 
 if (isset($_GET['eventId'])) {
   $eventId = htmlspecialchars($_GET['eventId']);
@@ -11,6 +15,12 @@ if (isset($_GET['eventId'])) {
     
     $start_date = strtotime($event['start_at']);
     $end_date = strtotime($event['end_at']);
+
+    $eventStatus = getEventStatus($db, (int)$_GET['eventId'], (int)$user_id);
+
+    $participation = $eventStatus['participation'];
+    $nonparticipation = $eventStatus['nonparticipation'];
+    $notsubmitted = $eventStatus['notsubmitted'];
 
     $eventMessage = date("Y年m月d日", $start_date) . '（' . get_day_of_week(date("w", $start_date)) . '） ' . date("H:i", $start_date) . '~' . date("H:i", $end_date) . 'に' . $event['name'] . 'を開催します。<br>ぜひ参加してください。';
 
@@ -29,6 +39,7 @@ if (isset($_GET['eventId'])) {
       'message' => $eventMessage,
       'status' => $status,
       'deadline' => date("m月d日", strtotime('-3 day', $end_date)),
+      'eventStatus' => $eventStatus,
     ];
     
     echo json_encode($array, JSON_UNESCAPED_UNICODE);

--- a/src/index.php
+++ b/src/index.php
@@ -1,5 +1,6 @@
 <?php
 require('dbconnect.php');
+require('./models/event_attendance.php');
 
 session_start();
 
@@ -13,7 +14,7 @@ $_GET["status"];
 $today = date("Y-m-d");
 $user_id = $_SESSION['user_id'];
 if (!$_GET["status"]) {
-  $stmt = $db->query("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE events.start_at >= '$today' GROUP BY events.id ORDER BY events.start_at ASC");
+  $stmt = $db->query("SELECT events.id as eventId, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE events.start_at >= '$today' GROUP BY events.id ORDER BY events.start_at ASC");
   $stmt->execute();
   $events = $stmt->fetchAll();
 } elseif($_GET["status"] == 1 || $_GET["status"] == 2 || $_GET["status"] == 3) {
@@ -31,8 +32,6 @@ if (!$_GET["status"]) {
         $events = $stmt->fetchAll();
       };
 }
-
-
 
 function get_day_of_week($w)
 {
@@ -123,7 +122,8 @@ function get_day_of_week($w)
           $end_date = strtotime($event['end_at']);
           $day_of_week = get_day_of_week(date("w", $start_date));
           ?>
-          <div class="modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event-<?php echo $event['eventId']; ?>">
+          <form class="modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event-<?= $event['eventId']; ?>">
+          <input type="hidden" name="eventId" value="<?= $event['name'] ?>">
             <div>
               <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>
               <p><?php echo date("Y年m月d日（${day_of_week}）", $start_date); ?></p>
@@ -150,7 +150,7 @@ function get_day_of_week($w)
               </div>
               <p class="text-sm"><span class="text-xl"><?php echo $event['total_participants']; ?></span>人参加 ></p>
             </div>
-          </div>
+          </form>
         <?php endforeach; ?>
       </div>
     </div>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -26,6 +26,11 @@ async function openModal(eventId) {
     const url = '/api/getModalInfo.php?eventId=' + eventId
     const res = await fetch(url)
     const event = await res.json()
+    console.log(event.eventStatus[0])
+    let participation = event.eventStatus[0].participation;
+    let nonparticipation = event.eventStatus[0].nonparticipation;
+    let notsubmitted = event.eventStatus[0].notsubmitted;
+
     let modalHTML = `
       <h2 class="text-md font-bold mb-3">${event.name}</h2>
       <p class="text-sm">${event.date}（${event.day_of_week}）</p>
@@ -50,11 +55,22 @@ async function openModal(eventId) {
             <p class="text-xs text-yellow-400">期限 ${event.deadline}</p>
             -->
           </div>
-          <div class="flex mt-5">
-            <button class="flex-1 bg-blue-500 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="participateEvent(${eventId})">参加する</button>
-            <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="nonparticipateEvent(${eventId})">参加しない</button>
-          </div>
         `
+        if (participation == 1) {
+          modalHTML += `<div class="flex mt-5">
+        <button class="flex-1 bg-blue-500 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="participateEvent(${eventId})" disabled>参加する</button>
+        <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="nonparticipateEvent(${eventId})">参加しない</button>
+      </div>`
+      }else if( nonparticipation == 1){
+        modalHTML += `<div class="flex mt-5">
+        <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="participateEvent(${eventId})">参加する</button>
+        <button class="flex-1 bg-blue-500 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="nonparticipateEvent(${eventId})" disabled>参加しない</button>
+      </div>`
+      }else{ modalHTML += `<div class="flex mt-5">
+      <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="participateEvent(${eventId})">参加する</button>
+      <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="nonparticipateEvent(${eventId})">参加しない</button>
+    </div>`}
+
         break;
       case 1:
         modalHTML += `
@@ -98,7 +114,7 @@ async function participateEvent(eventId) {
       method: 'POST',
       body: formData
     }).then((res) => {
-      if(res.status !== 200) {
+      if (res.status !== 200) {
         throw new Error("system error");
       }
       return res.text();
@@ -119,7 +135,7 @@ async function nonparticipateEvent(eventId) {
       method: 'POST',
       body: formData
     }).then((res) => {
-      if(res.status !== 200) {
+      if (res.status !== 200) {
         throw new Error("system error");
       }
       return res.text();
@@ -131,6 +147,15 @@ async function nonparticipateEvent(eventId) {
   }
 }
 
+// let generations = [];
+// let objectGenerations = $('#jsGetVariable').data();
+
+// console.log(objectGenerations)
+// objectGenerations['name'].map(function(element) {
+//     const generation = Math.floor(element.generation)
+//     generations.push(generation);
+// });
+// generations = new Set(generations);
 
 
 

--- a/src/models/event_attendance.php
+++ b/src/models/event_attendance.php
@@ -1,0 +1,9 @@
+<?php
+//イベントとユーザで絞り込む
+function getEventStatus($db, $eventId, $userId)
+{
+    $stmt = $db->prepare("select participation, nonparticipation, notsubmitted  from event_attendance where event_id = $eventId and user_id = $userId ");
+    $stmt->execute();
+    $output = $stmt->fetchAll();
+    return $output;
+}

--- a/src/models/events.php
+++ b/src/models/events.php
@@ -7,3 +7,4 @@ function eventRead($db)
     $output = $stmt->fetchAll();
     return $output;
 }
+


### PR DESCRIPTION
## 関連イシュー
<!-- このプルリクエストに関連するイシューリンクを記載してください。 -->
#41 

## 検証したこと
<!-- どんなことを検証したのか記載してください？ -->
<!-- 例）〇〇が動くことは確認しました -->
### 参加というステータスになっているイベントについて、参加ボタンを押してもpost処理が働かない**
### 不参加というステータスになっているイベントについても、不参加ボタンを押した際にpost処理が働かない

## エビデンス
<!-- こちらに画面キャプチャを貼ってください -->
### 以下がログインしているユーザのイベント出欠に関わる情報である
![image](https://user-images.githubusercontent.com/86541009/188916800-5749360d-29f1-48f5-8346-0acdbd71f3ae.png)

### 以下がイベントの情報である
![image](https://user-images.githubusercontent.com/86541009/188917030-43dab003-b375-4eac-8490-f8e0dd4cbfc2.png)

### つまり、

- ### イベントIDが4のリアイベについて、このユーザは参加となっている
- ### イベントIDが2の橫モクについて、このユーザは不参加となっている

### 以下のようにリアイベを選択したときには、参加ボタンが青色で塗りつぶされている
![image](https://user-images.githubusercontent.com/86541009/188917486-512c2ba1-bc09-4c5d-8633-f7687bee74a7.png)

### 以下のように橫モクを選択したときには、不参加ボタンが青色で塗りつぶされている
![image](https://user-images.githubusercontent.com/86541009/188918060-026fb2cd-324d-4b9c-825d-8bb19ee1e832.png)

### このように、イベントの参加、不参加によってスタイルを変えられているということは、styleと同じ属性である、disabeleを付与することで簡単に活性、非活性においても同様のことができるので、イシュー条件を満たしたことのエビデンスになる。