### PR TITLE
イベント参加答者を表示

### DIFF
--- a/src/mailtest.php
+++ b/src/mailtest.php
@@ -1,5 +1,6 @@
 <?php
-
+require("dbconnect.php");
+require(realpath("models/event_attendance.php"));
 mb_language('ja');
 mb_internal_encoding('UTF-8');
 
@@ -22,3 +23,6 @@ EOT;
 
 mb_send_mail($to, $subject, $body, $headers);
 echo "メールを送信しました";
+
+$condition = 'participation';
+var_dump(getUserByAttendanceStatus($db, $condition));

--- a/src/models/event_attendance.php
+++ b/src/models/event_attendance.php
@@ -7,3 +7,12 @@ function getEventStatus($db, $eventId, $userId)
     $output = $stmt->fetchAll();
     return $output;
 }
+
+//イベントの参加答者を取得
+function getUserByAttendanceStatus($db, $condition)
+{
+    $stmt = $db->prepare("select events.name, events.start_at, users.name from event_attendance inner join users on users.id = event_attendance.user_id inner join events on events.id = event_attendance.event_id where $condition = 1 && start_at >= now() order by events.name");
+    $stmt->execute();
+    $output = $stmt->fetchAll();
+    return $output;
+}


### PR DESCRIPTION
## 関連イシュー
<!-- このプルリクエストに関連するイシューリンクを記載してください。 -->
#44 

## 検証したこと
<!-- どんなことを検証したのか記載してください？ -->
<!-- 例）〇〇が動くことは確認しました -->
sqlを叩いて、イベントの名前と開催日時と、それぞれのイベントの参加者一覧が出力されることを確認

## エビデンス
<!-- こちらに画面キャプチャを貼ってください -->
### 前提として、以下がユーザ一覧であり、
![image](https://user-images.githubusercontent.com/86541009/188934056-175bfb1c-3a12-45a2-a4bc-3438b0eeee59.png)

### 以下がイベント一覧である
![image](https://user-images.githubusercontent.com/86541009/188933780-78e49f62-8977-4334-9e20-d8a765a5d730.png)

### これを踏まえて、以下のevent_attendanceを見てみると、
![image](https://user-images.githubusercontent.com/86541009/188933899-c5a4e809-e0a3-4bb6-89d2-4297b3dd0a6d.png)

- ### イベントIDが2にはユーザIDが1のユーザのみ参加
- ### イベントIDが3にはユーザIDが1と3のユーザが参加
- ### イベントIDが4にはユーザIDが1と3と4のユーザが参加

ということがわかる

つまり、

- ### よこもくには、つよちゃんのみ参加
- ### たてもくには、つよちゃんとかずきが参加
- ### リアイベには、つよちゃんとかずきとなおきが参加

ということがわかる

### これらを踏まえて、実際に、今回の要件を満たしたかどうかの証拠を乗せると以下のようになる

![image](https://user-images.githubusercontent.com/86541009/188935640-be817e9b-8e19-404c-bb32-2d6473fabf8e.png)
