### PR TITLE
adminFeature/48

### DIFF
--- a/src/addEvent.php
+++ b/src/addEvent.php
@@ -1,26 +1,45 @@
+<?php
+require('dbconnect.php');
+require('./models/events.php');
+  if ($_POST) {
+    //その他の取得
+    $name = $_POST['name'];
+    var_dump($_POST['started-time']);
+    $startedTime = $_POST['started-time'];
+    $startedTime = strtotime($startedTime);
+    var_dump($startedTime);
+    $startedTime = DateTime::createFromFormat(DateTime::ISO8601,$startedTime);
+    $finishedTime = $_POST['finished-time'];
+    $finishedTime = DateTime::createFromFormat(DateTime::ISO8601,$finishedTime);
+    $deadline = $_POST['deadline'];
+    $deadline = DateTime::createFromFormat(DateTime::ISO8601,$deadline);
+
+    $detail = $_POST['detail'];
+    eventCreate($db, $name, $startedTime,$finishedTime, $deadline, $detail);
+    header('Location: adminTop.php' );
+  }
+?>
 <?php include('head.php')?>
 <body class="bg-gray-100 h-screen w-screen">
 <?php include('header.php')?>
   <main class="bg-gray-100 flex justify-center h-screen w-screen">
-  <div class="w-full text-center">
+  <form action="addEvent.php" method="POST" class="w-full text-center">
   <h1 class="text-2xl font-bold mt-5">イベント追加画面</h1>
     <p class="mt-3 text-left ml-12 mb-2">イベント名</p>
-      <input type="text" placeholder="イベント" class="w-3/4 h-15 p-4 text-sm mb-3 rounded-lg" required>
-    <p class="mt-3 text-left ml-12 mb-2">日程</p>
-      <input type="date" name="effective-date" class="w-3/4 h-15 p-4 text-sm mb-3 rounded-lg" required>
+      <input name="name" type="text" placeholder="イベント名" class="w-3/4 h-15 p-4 text-sm mb-3 rounded-lg" required>
     <p class="mt-3 text-left ml-12 mb-2">開始時刻</p>
-      <input type="time" name="started-time" class="w-3/4 h-15 p-4 text-sm mb-3 rounded-lg" required>
+      <input type="datetime-local" name="started-time" class="w-3/4 h-15 p-4 text-sm mb-3 rounded-lg" required>
       <p class="mt-3 text-left ml-12 mb-2">終了時刻</p>
-      <input type="time" name="finished-time" class="w-3/4 h-15 p-4 text-sm mb-3 rounded-lg" required>
+      <input type="datetime-local" name="finished-time" class="w-3/4 h-15 p-4 text-sm mb-3 rounded-lg" required>
       <p class="mt-3 text-left ml-12 mb-2">締切日（任意）</p>
-    <input type="date" name="deadline" class="w-3/4 h-15 p-4 text-sm mb-3 rounded-lg">
+    <input type="datetime-local" name="deadline" class="w-3/4 h-15 p-4 text-sm mb-3 rounded-lg">
       <p class="mt-3 text-left ml-12 mb-2">イベント詳細</p>
-      <textarea rows="10" cols="60" class="w-3/4 h-20 p-4 text-sm mb-3 rounded-lg"></textarea>
+      <textarea name="detail" rows="10" cols="60" class="w-3/4 h-20 p-4 text-sm mb-3 rounded-lg"></textarea>
     <div class="flex justify-center">
-      <div class="mt-3 text-center w-3/4 h-10 bg-gradient-to-r from-blue-500 to-blue-200 rounded-full" required>
-        <p class="text-white font-bold leading-10">追加</p>
+      <div class="mt-3 text-center w-3/4 h-10 bg-gradient-to-r from-blue-500 to-blue-200 rounded-full">
+        <button type="submit" class="text-white font-bold leading-10">追加</button>
       </div>
     </div>
-  </div>
+  </form>
   </main>
 </body>

--- a/src/adminLogin.php
+++ b/src/adminLogin.php
@@ -48,7 +48,7 @@ if(!empty($_POST)) {
   </header>
   <main class="bg-gray-100 h-screen">
   <div class="w-full mx-auto p-5">
-    <div class="font-bold text-base mt-4 mb-3">ログイン</div>
+    <div class="font-bold text-base mt-4 mb-3">管理者用ログイン</div>
     <form action="/adminLogin.php" method="POST">
     <input type="email" name="email" placeholder="メールアドレス" class="w-full p-4 text-sm mb-3 ">
         <input type="password" name="password" placeholder="パスワード" class="w-full p-4 text-sm mb-3">

--- a/src/adminLogin.php
+++ b/src/adminLogin.php
@@ -1,3 +1,33 @@
+<?php
+require("./dbconnect.php");
+
+session_name();
+session_start();
+
+unset($_SESSION['admin_id']);
+
+if(!empty($_POST)) {
+  $email = $_POST['email'];
+  $password = $_POST['password'];
+  if(!empty($email) && !empty($password)){
+  $login = $db->prepare('SELECT * FROM users WHERE email=? AND admin = 1');
+  $login->execute(array(
+    $email
+  ));
+  $user = $login->fetch();
+  if(!empty($user) && password_verify($password, $user['password'])){
+    $_SESSION['admin_id'] = $user['id']; 
+    header("Location: http://" . $_SERVER['HTTP_HOST'] . "/adminTop.php");
+    exit();
+  }else{
+    $err_msg = "メールまたはパスワードが違います";
+  }
+}else{
+  $err_msg = "メールまたはパスワードが違います";
+}
+}
+?>
+
 <!DOCTYPE html>
 <html lang="ja">
 
@@ -19,9 +49,13 @@
   <main class="bg-gray-100 h-screen">
   <div class="w-full mx-auto p-5">
     <div class="font-bold text-base mt-4 mb-3">ログイン</div>
-    <input type="email" placeholder="メールアドレス" class="w-full p-4 text-sm mb-3 ">
-        <input type="password" placeholder="パスワード" class="w-full p-4 text-sm mb-3">
+    <form action="/adminLogin.php" method="POST">
+    <input type="email" name="email" placeholder="メールアドレス" class="w-full p-4 text-sm mb-3 ">
+        <input type="password" name="password" placeholder="パスワード" class="w-full p-4 text-sm mb-3">
     </div>
+    <?php 
+        echo $err_msg;
+        ?>
     <input type="submit" value="ログイン" class="cursor-pointer w-full p-3 text-md text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300">
       </form>
       <div class="text-center text-xs text-gray-400 mt-6">

--- a/src/adminTop.php
+++ b/src/adminTop.php
@@ -1,7 +1,12 @@
-<!DOCTYPE html>
-<html lang="ja">
 <?php
 require('dbconnect.php');
+
+session_start();
+
+if (empty($_SESSION['admin_id'])) {
+  header("Location: http://" . $_SERVER['HTTP_HOST'] . "/adminlogin.php");
+  exit();
+}
 
 $stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id GROUP BY events.id');
 $events = $stmt->fetchAll();
@@ -11,6 +16,8 @@ function get_day_of_week ($w) {
   return $day_of_week_list["$w"];
 }
 ?>
+<!DOCTYPE html>
+<html lang="ja">
 <?php include('head.php');?>
 
 <body>

--- a/src/adminTop.php
+++ b/src/adminTop.php
@@ -8,8 +8,9 @@ if (empty($_SESSION['admin_id'])) {
 require("dbconnect.php");
 include('header.php');
 
+$today = date("Y-m-d");
 
-$stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id GROUP BY events.id');
+$stmt = $db->query("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE events.start_at >= '$today' GROUP BY events.id");
 $events = $stmt->fetchAll();
 
 function get_day_of_week($w)

--- a/src/adminTop.php
+++ b/src/adminTop.php
@@ -11,7 +11,6 @@ function get_day_of_week ($w) {
   return $day_of_week_list["$w"];
 }
 ?>
-
 <?php include('head.php');?>
 
 <body>

--- a/src/editEvent.php
+++ b/src/editEvent.php
@@ -6,14 +6,12 @@
   <h1 class="text-2xl font-bold mt-5">イベント編集画面</h1>
     <p class="mt-3 text-left ml-12 mb-2">イベント名</p>
       <input type="text" placeholder="イベント" class="w-3/4 h-15 p-4 text-sm mb-3 rounded-lg" required>
-    <p class="mt-3 text-left ml-12 mb-2">日程</p>
-      <input type="date" name="effective-date" class="w-3/4 h-15 p-4 text-sm mb-3 rounded-lg" required>
     <p class="mt-3 text-left ml-12 mb-2">開始時刻</p>
-      <input type="time" name="started-time" class="w-3/4 h-15 p-4 text-sm mb-3 rounded-lg" required>
+      <input type="datetime-local" name="started-time" class="w-3/4 h-15 p-4 text-sm mb-3 rounded-lg" required>
       <p class="mt-3 text-left ml-12 mb-2">終了時刻</p>
-      <input type="time" name="finished-time" class="w-3/4 h-15 p-4 text-sm mb-3 rounded-lg" required>
+      <input type="datetime-local" name="finished-time" class="w-3/4 h-15 p-4 text-sm mb-3 rounded-lg" required>
       <p class="mt-3 text-left ml-12 mb-2">締切日（任意）</p>
-    <input type="date" name="deadline" class="w-3/4 h-15 p-4 text-sm mb-3 rounded-lg" required>
+    <input type="datetime-local" name="deadline" class="w-3/4 h-15 p-4 text-sm mb-3 rounded-lg" required>
       <p class="mt-3 text-left ml-12 mb-2">イベント詳細</p>
       <textarea rows="10" cols="60" class="w-3/4 h-20 p-4 text-sm mb-3 rounded-lg"></textarea>
     <div class="flex justify-center mb-10">

--- a/src/models/events.php
+++ b/src/models/events.php
@@ -7,3 +7,54 @@ function eventRead($db)
     $output = $stmt->fetchAll();
     return $output;
 }
+
+// 追加
+function eventCreate($db, $name, $start_at, $end_at, $deadline, $detail)
+{
+    $result = False;
+    try {
+    $stmt = $db->prepare(
+            "INSERT INTO
+    `events` (
+    `name`,
+    `start_at`,
+    `end_at`,
+    `deadline`,
+    `detail`
+    )
+    VALUES(?,?,?,?,?)"
+        );
+
+        $stmt->bindValue(1, $name, PDO::PARAM_STR);
+        $stmt->bindValue(2, $start_at, PDO::PARAM_STR);
+        $stmt->bindValue(3, $end_at, PDO::PARAM_STR);
+        $stmt->bindValue(4, $deadline, PDO::PARAM_INT);
+        $stmt->bindValue(5, $detail, PDO::PARAM_INT);
+        $stmt->execute();
+    } catch (\Exception $e) {
+        echo $e->getMessage();
+        return $result;
+        //ここでエラーページに飛ばしたい
+        //→その際にもどるボタンで、前いたページに遷移させる
+    }
+}
+
+// 編集
+function eventUpdate($db, $name, $start_at, $end_at, $deadline, $detail, $condition)
+{
+    $result = False;
+    try {
+        $stmt = $db->prepare("UPDATE `events` SET name=?, `start_at`=?, `end_at`=?, `deadline`=? ,`detail`=? WHERE $condition");
+        $stmt->bindValue(1, $name, PDO::PARAM_STR);
+        $stmt->bindValue(2, $start_at, PDO::PARAM_STR);
+        $stmt->bindValue(3, $end_at, PDO::PARAM_STR);
+        $stmt->bindValue(4, $deadline, PDO::PARAM_STR);
+        $stmt->bindValue(5, $detail, PDO::PARAM_STR);
+        $stmt->execute();
+    } catch (\Exception $e) {
+        echo $e->getMessage();
+        return $result;
+        //ここでエラーページに飛ばしたい
+        //→その際にもどるボタンで、前いたページに遷移させる
+    }
+}

--- a/src/style.css
+++ b/src/style.css
@@ -293,8 +293,7 @@ main footer .secondary-links .social li > a:hover {
   display: flex;
   justify-content: center;
   padding:-5% 15%;
-
-  margin: 0px auto;
+  margin: 15px auto;
   width: 85%;
   height: 25%;
   line-height: 30px;


### PR DESCRIPTION
## 関連イシュー
管理画面 Issue1 画面からイベントを登録出来るようにする 項目はイベント名、開催日時、イベント内容は空 #48
**終了条件**
管理画面からイベント名、開催日時を入力して、イベント登録できる
管理画面には管理者のみログイン出来る

## 検証したこと
・管理画面からイベント登録（確認済み）
・追加したものが一覧に表示される＋DBに保存される（確認済み）
・開始時刻が終了時刻を超えない＋締め切り時間が開始時刻を超えないバリデーション（確認済み）
・管理者のみがログイン可能（確認済み）

## エビデンス
まず、管理者のみログインについて
![image](https://user-images.githubusercontent.com/94731753/188933970-8719aa38-6c1e-4ede-a971-a2a9e3d2aa1b.png)
adminカラムが1のものが管理者なので、今回user_id=2のものでログインを試みると
![image](https://user-images.githubusercontent.com/94731753/188935423-23bedafe-ac04-4dd2-b690-6572fbe7db17.png)
成功して入ることができる、逆に管理者ではないアカウントで入ろうとしても入れない。
右上のハンバーガーメニューからイベント追加画面に移動し、イベント追加のための情報を入力し、
![image](https://user-images.githubusercontent.com/94731753/188935824-eff7deb4-7359-4aa0-afd2-8660e91c5395.png)
![image](https://user-images.githubusercontent.com/94731753/188936154-3e9d7bc2-e6d4-46a9-8e86-1cf89f971762.png)
下の追加ボタンを押すと追加可能
![image](https://user-images.githubusercontent.com/94731753/188936317-8877504e-a455-4a5e-a9d7-1a733b6932ea.png)
追加後、また、上記のバリデーションを実装（ログインに関してはユーザーのログインと同じバリデーションを実装）



