### PR TITLE
各イベントに対する未提出者を出力

### DIFF
--- a/src/mailtest.php
+++ b/src/mailtest.php
@@ -26,3 +26,4 @@ echo "メールを送信しました";
 
 $condition = 'participation';
 var_dump(getUserByAttendanceStatus($db, $condition));
+var_dump(getUserByAttendanceStatus($db, 'notsubmitted'));


### PR DESCRIPTION
## 関連イシュー
<!-- このプルリクエストに関連するイシューリンクを記載してください。 -->
#51 

## 検証したこと
<!-- どんなことを検証したのか記載してください？ -->
<!-- 例）〇〇が動くことは確認しました -->
sqlを叩いて、イベントの名前と開催日時と、それぞれのイベントの未提出者一覧が出力されることを確認

## エビデンス
<!-- こちらに画面キャプチャを貼ってください -->
### 前提として、以下がユーザ一覧であり、
![image](https://user-images.githubusercontent.com/86541009/188934056-175bfb1c-3a12-45a2-a4bc-3438b0eeee59.png)

### 以下がイベント一覧である(一番上の縦モクのみ開催日が現在日時なので、今回は無視する)
![image](https://user-images.githubusercontent.com/86541009/188933780-78e49f62-8977-4334-9e20-d8a765a5d730.png)

### これを踏まえて、以下のevent_attendanceを見てみると、
![image](https://user-images.githubusercontent.com/86541009/188933899-c5a4e809-e0a3-4bb6-89d2-4297b3dd0a6d.png)

- ### イベントIDが2はユーザIDが3のユーザのみ未提出
- ### イベントIDが3はユーザIDが4のユーザのみ未提出
- ### イベントIDが4はユーザIDが2のみ未提出
ということがわかる

つまり、

- ### よこもくは、かずきのみ未提出
- ### たてもくは、なおきのみ未提出
- ### リアイベは、れいのみ未提出
ということがわかる

### これらを踏まえて、実際に、今回の要件を満たしたかどうかの証拠を乗せると以下のようになる

![image](https://user-images.githubusercontent.com/86541009/188942723-12d4f872-5fd9-4e97-8c49-fa9cc35198f0.png)

