### PR TITLE
管理画面からイベント詳細追加完了

### DIFF
--- a/src/addEvent.php
+++ b/src/addEvent.php
@@ -11,6 +11,8 @@ require('./models/events.php');
     $deadline = $_POST['deadline'];
     $dead = strtotime($deadline);
     $detail = $_POST['detail'];
+    if(strlen($name) < 255){
+    if(strlen($detail) < 255){
     if($finish >= $start){
       if($start >= $dead){
       eventCreate($db, $name, $startedTime, $finishedTime, $deadline, $detail); 
@@ -21,6 +23,12 @@ require('./models/events.php');
     }else{
       $err_msg = "開始時刻を終了時刻より前にしてください。";
     }
+    }else{
+      $err_msg = "詳細は255文字以内で記載してください。";
+    }
+  }else{
+      $err_msg = "イベント名は255文字以内で記載してください。";
+  }
   }
 ?>
 <!-- <body class="bg-gray-100 h-screen w-screen"> -->
@@ -47,9 +55,11 @@ require('./models/events.php');
       <p class="mt-3 text-left ml-12 mb-2">イベント詳細</p>
       <textarea name="detail" rows="10" cols="60" class="w-3/4 h-20 p-4 text-sm mb-3 rounded-lg"></textarea>
     <div class="flex justify-center">
-      <div class="mt-3 text-center w-3/4 h-10 bg-gradient-to-r from-blue-500 to-blue-200 rounded-full">
-        <button type="submit" class="text-white font-bold leading-10">追加</button>
-      </div>
+    <button type="submit" class="text-white font-bold leading-10 mt-3 text-center w-4/5 h-10 bg-gradient-to-r from-blue-500 to-blue-200 rounded-full">
+      <!-- <div class="mt-3 text-center w-100 h-10 bg-gradient-to-r from-blue-500 to-blue-200 rounded-full"> -->
+        追加
+      <!-- </div> -->
+    </button>
     </div>
   </form>
   </main>

--- a/src/addMember.php
+++ b/src/addMember.php
@@ -79,9 +79,9 @@ require(realpath("header.php"));
     }
       ?>
       <div class="flex justify-center">
-        <div class="mt-3 text-center w-3/4 h-10 bg-gradient-to-r from-blue-500 to-blue-200 rounded-full">
-          <input type="submit" class="text-white font-bold leading-10" value="サインアップ">
-        </div>
+        <label for="sign_up" class="mt-3 text-center w-3/4 h-10 bg-gradient-to-r from-blue-500 to-blue-200 rounded-full">
+          <input id="sign_up" type="submit" class="bg-transparent text-white font-bold leading-10" value="サインアップ">
+        </label>
       </div>
     </form>
   </div>

--- a/src/editEvent.php
+++ b/src/editEvent.php
@@ -5,7 +5,6 @@ include('header.php') ?>
   <div class="w-full text-center h-full">
     <h1 class="text-2xl font-bold mt-5">イベント編集画面</h1>
     <p class="mt-3 text-left ml-12 mb-2">イベント名</p>
-<<<<<<< HEAD
       <input type="text" placeholder="イベント" class="w-3/4 h-15 p-4 text-sm mb-3 rounded-lg" required>
     <p class="mt-3 text-left ml-12 mb-2">開始時刻</p>
       <input type="datetime-local" name="started-time" class="w-3/4 h-15 p-4 text-sm mb-3 rounded-lg" required>
@@ -15,19 +14,6 @@ include('header.php') ?>
     <input type="datetime-local" name="deadline" class="w-3/4 h-15 p-4 text-sm mb-3 rounded-lg" required>
       <p class="mt-3 text-left ml-12 mb-2">イベント詳細</p>
       <textarea rows="10" cols="60" class="w-3/4 h-20 p-4 text-sm mb-3 rounded-lg"></textarea>
-=======
-    <input type="text" placeholder="イベント" class="w-3/4 h-15 p-4 text-sm mb-3 rounded-lg" required>
-    <p class="mt-3 text-left ml-12 mb-2">日程</p>
-    <input type="date" name="effective-date" class="w-3/4 h-15 p-4 text-sm mb-3 rounded-lg" required>
-    <p class="mt-3 text-left ml-12 mb-2">開始時刻</p>
-    <input type="time" name="started-time" class="w-3/4 h-15 p-4 text-sm mb-3 rounded-lg" required>
-    <p class="mt-3 text-left ml-12 mb-2">終了時刻</p>
-    <input type="time" name="finished-time" class="w-3/4 h-15 p-4 text-sm mb-3 rounded-lg" required>
-    <p class="mt-3 text-left ml-12 mb-2">締切日（任意）</p>
-    <input type="date" name="deadline" class="w-3/4 h-15 p-4 text-sm mb-3 rounded-lg" required>
-    <p class="mt-3 text-left ml-12 mb-2">イベント詳細</p>
-    <textarea rows="10" cols="60" class="w-3/4 h-20 p-4 text-sm mb-3 rounded-lg"></textarea>
->>>>>>> ed04cce68e7bd6c4f5aa733211bebd32b79bd101
     <div class="flex justify-center mb-10">
       <div class="mt-3 text-center w-3/4 h-10 bg-gradient-to-r from-blue-500 to-blue-200 rounded-full" required>
         <p class="text-white font-bold leading-10">変更</p>


### PR DESCRIPTION
## 関連イシュー
管理画面 Issue2 画面からイベント内容も登録出来るようにする #49
**終了条件**
管理画面からイベント名、開催日時、イベント内容を入力して、イベント登録できる
管理画面には管理者のみログイン出来る

## 検証したこと
・イベント詳細の追加（255文字以内）（確認済み）
・管理者のみログインできること（確認済み）

## エビデンス
![スクリーンショット 2022-09-08 2 38 00](https://user-images.githubusercontent.com/94731753/188946142-702904da-9c21-46f8-893c-f779c9679b8c.png)
追加前のテーブルが上の通りで、これに対して下記のようにイベント追加画面で情報を入力すると
![スクリーンショット 2022-09-08 2 40 37](https://user-images.githubusercontent.com/94731753/188946338-7107b22e-5c48-4e53-92f2-9c5e4016ab3f.png)
追加され、下記のようにテーブルに情報が追加され、一覧にも表示される。
![スクリーンショット 2022-09-08 2 41 07](https://user-images.githubusercontent.com/94731753/188946504-2aa969cf-3e18-48e8-a9d6-7c69509a5057.png)
![image](https://user-images.githubusercontent.com/94731753/188946557-20706823-bff1-428a-b8d5-3e929fabd57f.png)

