### PR TITLE
Feature/50

### DIFF
--- a/src/adminTop.php
+++ b/src/adminTop.php
@@ -29,7 +29,7 @@ function get_day_of_week($w)
         <a class="text-sm leading-3"><?= date('H:i', strtotime($event['start_at'])) . '~' . date('H:i', strtotime($event['end_at'])) ?></a>
       </div>
       <div class="pt-3 ml-10 text-right align-middle text-blue-400"><a href="#" class=" text-sm">参加者一覧</a><br>
-        <a href="editEvent.php" class="text-sm">編集</a><br>
+        <a href="editEvent.php?id=<?=$event['id']?>" class="text-sm">編集</a><br>
         <a href="#" class="text-sm">削除</a>
       </div>
     </div>


### PR DESCRIPTION
## 関連イシュー
<!-- このプルリクエストに関連するイシューリンクを記載してください。 -->
管理画面 Issue3 画面からイベント情報を変更出来るようにする  #50 

*** 終了条件 ***

- 管理画面から登録済みのイベント一覧が確認できること、
- また、イベントを選択してイベント名、開催日時、イベント内容を変更できること
- 管理画面には管理者のみログイン出来る

## 検証したこと
<!-- どんなことを検証したのか記載してください？ -->
<!-- 例）〇〇が動くことは確認しました -->

- 管理画面から登録済みのイベント一覧が確認できた (確認済み)
- また、イベントを選択してイベント名、開催日時、イベント内容を変更できる(確認済み)
- 管理画面には管理者のみログイン出来る(確認済み)

## エビデンス
<!-- こちらに画面キャプチャを貼ってください -->
<img width="1140" alt="image" src="https://user-images.githubusercontent.com/94731753/189016637-98278b58-94a7-432b-9386-c80d91925228.png">
現状のイベント一覧が上記で、それに対し、
<img width="408" alt="image" src="https://user-images.githubusercontent.com/94731753/189016706-8a80a817-5842-48af-a856-f2a286ab63c1.png">
管理画面では今日（9/8 11:00現在）以降の登録済みのイベント一覧が表示されている
次に上記のテーブル情報のもと、リアイベイベントの名前をリアイベ2に、開催日時を9/23 19:00に、イベントは内容をサッカーするぞに変更すると
<img width="386" alt="image" src="https://user-images.githubusercontent.com/94731753/189017692-a1e1d121-400b-43bd-8a48-67423a591507.png">
<img width="384" alt="image" src="https://user-images.githubusercontent.com/94731753/189017744-dca57f66-afd8-412c-80fb-d62ee834609b.png">
<img width="1146" alt="image" src="https://user-images.githubusercontent.com/94731753/189017803-51ba0a5e-eec3-447e-a44f-60b6e157e244.png">
上記のように一覧表示、テーブル情報ともに変更が保存されていることが確認できる




