### PR TITLE
メール部分の共通化　参加者のみに前日通知機能完成

### DIFF
--- a/src/notifyEveryone.php
+++ b/src/notifyEveryone.php
@@ -1,7 +1,4 @@
-
-
 <?php
-
 
 require("dbconnect.php");
 mb_language('ja');
@@ -22,31 +19,4 @@ $stmt->execute();
 $events = $stmt->fetchAll();
 echo ($event_day);
 
-foreach ( $events as $event){
-
-    
-    
-    $to = $event['userEmail'];
-    $subject = "PHPからメール送信サンプル";
-    $headers = ["From"=>"system@posse-ap.com", "Content-Type"=>"text/plain; charset=UTF-8", "Content-Transfer-Encoding"=>"8bit"];
-    $user_name = $event['userName'];
-    $event_start_date = $event['start_at'];
-    $event_end_date = $event['end_at'];
-    $event_name = $event['name'];
-    $event_detail = $event['detail'];
-    $event_body =
-    <<<EOT
-    {$user_name}さん
-    ${event_start_date}~${event_end_date}に${event_name}を開催します。
-    参加／不参加の回答をお願いします。
-    イベント内容：${event_detail}
-    http://localhost/
-
-    EOT;
-    
-    mb_send_mail($to, $subject, $event_body, $headers);
-    echo "$to";
-    echo "$subject";
-    echo "$event_body";
-    echo "$headers";
-}
+require('notifymail.php');

--- a/src/notifyParticipant.php
+++ b/src/notifyParticipant.php
@@ -1,0 +1,22 @@
+<?php
+
+require("dbconnect.php");
+mb_language('ja');
+mb_internal_encoding('UTF-8');
+
+
+$objDateTime = new DateTime('tomorrow');
+$event_day=$objDateTime->format('Y-m-d');
+$stmt = $db->query("SELECT events.id AS eventId, event_attendance.id, events.name, events.start_at,events.end_at,events.detail,event_attendance.user_id,users.name AS userName,users.email AS userEmail,event_attendance.participation,event_attendance.nonparticipation,event_attendance.notsubmitted, count(event_attendance.id) AS total_participants  
+                    FROM event_attendance 
+                    INNER JOIN events ON event_attendance.event_id=events.id 
+                    INNER JOIN users ON event_attendance.user_id=users.id 
+                    WHERE  DATE_FORMAT(events.start_at, '%Y-%m-%d') = '$event_day' AND event_attendance.participation='1'
+                    GROUP BY  event_attendance.id 
+                    ORDER BY events.start_at 
+                    ASC");
+$stmt->execute();
+$events = $stmt->fetchAll();
+echo ($event_day);
+
+require('notifymail.php');

--- a/src/notifymail.php
+++ b/src/notifymail.php
@@ -1,0 +1,31 @@
+
+
+<?php
+
+
+
+foreach ( $events as $event){
+
+    $to = $event['userEmail'];
+    $subject = "イベントのお知らせ";
+    $headers = ["From"=>"system@posse-ap.com", "Content-Type"=>"text/plain; charset=UTF-8", "Content-Transfer-Encoding"=>"8bit"];
+    $user_name = $event['userName'];
+    $event_start_date = $event['start_at'];
+    $event_end_date = $event['end_at'];
+    $event_name = $event['name'];
+    $event_detail = $event['detail'];
+    $event_body =
+    <<<EOT
+    {$user_name}さん
+    ${event_start_date}~${event_end_date}に${event_name}を開催します。
+    イベント内容：${event_detail}
+    http://localhost/
+
+    EOT;
+    
+    mb_send_mail($to, $subject, $event_body, $headers);
+    echo "$to";
+    echo "$subject";
+    echo "$event_body";
+    echo "$headers";
+}


### PR DESCRIPTION
## 関連イシュー
<!-- このプルリクエストに関連するイシューリンクを記載してください。 -->
#46 

## 検証したこと
<!-- どんなことを検証したのか記載してください？ -->
<!-- 例）〇〇が動くことは確認しました -->

1. 前提：管理画面にて、イベント１〜１０という新規のイベントを作成し、9月9日に「イベント１」というものが開催されるようにした
2. test@posse-ap.comにて、イベント１への参加ボタンを押した
3. phpターミナル内で、参加者のみに前日通知を送信するファイルnotifyEveryone.phpを実行
4. test@posse-ap.com(ユーザー名はつよちゃん)にメールが送信されていることが確認できた
5. メールホグにてtest@poss-ap.comにメールが送信されていることが確認できた

## エビデンス
<!-- こちらに画面キャプチャを貼ってください -->

1.2.
<img width="351" alt="スクリーンショット 2022-09-08 15 32 14" src="https://user-images.githubusercontent.com/86545986/189052089-7c8e587c-c280-4ea4-b40c-0edf0752d9d4.png">
3.4.
<img width="504" alt="スクリーンショット 2022-09-08 15 32 38" src="https://user-images.githubusercontent.com/86545986/189052186-2e7dd143-c793-478a-bccd-716477e87c3f.png">

5.
<img width="825" alt="スクリーンショット 2022-09-08 15 33 10" src="https://user-images.githubusercontent.com/86545986/189052222-a8e1739b-dfd4-4ac6-9ade-f89eab4c6be1.png">

