### PR TITLE
未回答者に3日後の通知をする機能完成

### DIFF
--- a/src/notsubmit1day.php
+++ b/src/notsubmit1day.php
@@ -1,0 +1,23 @@
+<?php
+
+require("dbconnect.php");
+mb_language('ja');
+mb_internal_encoding('UTF-8');
+
+
+$objDateTime = new DateTime('tomorrow');
+$event_day=$objDateTime->format('Y-m-d');
+$stmt = $db->query("SELECT events.id AS eventId, event_attendance.id, events.name, events.start_at,events.end_at,events.detail,event_attendance.user_id,users.name AS userName,users.email AS userEmail,event_attendance.participation,event_attendance.nonparticipation,event_attendance.notsubmitted, count(event_attendance.id) AS total_participants  
+                    FROM event_attendance 
+                    INNER JOIN events ON event_attendance.event_id=events.id 
+                    INNER JOIN users ON event_attendance.user_id=users.id 
+                    WHERE  DATE_FORMAT(events.start_at, '%Y-%m-%d') = '$event_day' AND event_attendance.notsubmitted='1'
+                    GROUP BY  event_attendance.id 
+                    ORDER BY events.start_at 
+                    ASC");
+$stmt->execute();
+$events = $stmt->fetchAll();
+$title = "イベント前日です。このメールが送られた方は今すぐ回答をお願いします。";
+echo ($event_day);
+
+require('notsubmittedmail.php');

--- a/src/notsubmit3daysUnanser.php
+++ b/src/notsubmit3daysUnanser.php
@@ -5,7 +5,7 @@ mb_language('ja');
 mb_internal_encoding('UTF-8');
 
 
-$objDateTime = new DateTime('tomorrow');
+$objDateTime = new DateTime('+3 day ');
 $event_day=$objDateTime->format('Y-m-d');
 $stmt = $db->query("SELECT events.id AS eventId, event_attendance.id, events.name, events.start_at,events.end_at,events.detail,event_attendance.user_id,users.name AS userName,users.email AS userEmail,event_attendance.participation,event_attendance.nonparticipation,event_attendance.notsubmitted, count(event_attendance.id) AS total_participants  
                     FROM event_attendance 
@@ -17,7 +17,7 @@ $stmt = $db->query("SELECT events.id AS eventId, event_attendance.id, events.nam
                     ASC");
 $stmt->execute();
 $events = $stmt->fetchAll();
-$title = "イベント前日です。このメールが送られた方は今すぐ回答をお願いします。";
+$title = "イベント3日前です。このメールが送られた方は今すぐ回答をお願いします。";
 echo ($event_day);
 
 require('notsubmittedmail.php');


### PR DESCRIPTION
## 関連イシュー
<!-- このプルリクエストに関連するイシューリンクを記載してください。 -->
#53 

## 検証したこと
<!-- どんなことを検証したのか記載してください？ -->
<!-- 例）〇〇が動くことは確認しました -->

1. イベントは#46で作成したイベントを使用
2. プルリク作成日の3日後2022-09-11にイベント３を開催
3. test@posse-ap.comのアカウントでログインし、イベント３を参加にする
4. test@posse-ap.comのアカウント以外は未提出の状態である（３名：れい、かずき、なおき）
5. phpのターミナルにてphp notsubmit3daysUnanser.phpを実行し、３名に対してイベントの前日の通知が来ていることを確認(Unanserはファイル名をnotsubmit3daysUnanswer.phpとするつもりが誤字りました　なのでそのままです)
6. mailhogにて、3人にイベントの前日と回答を促進する通知が来ていることを確認

## エビデンス
<img width="1156" alt="スクリーンショット 2022-09-08 16 51 45" src="https://user-images.githubusercontent.com/86545986/189075153-68ed305e-6c5f-4a76-ac52-b5eed2eac1bb.png">
<img width="1152" alt="スクリーンショット 2022-09-08 16 53 52" src="https://user-images.githubusercontent.com/86545986/189075538-77faf10f-4dac-4b00-932f-5555805a43d2.png">
<img width="1082" alt="スクリーンショット 2022-09-08 17 07 22" src="https://user-images.githubusercontent.com/86545986/189075591-af748e49-600e-4510-81e1-a3b81ef6a6cb.png">

<img width="766" alt="スクリーンショット 2022-09-08 17 35 08" src="https://user-images.githubusercontent.com/86545986/189075680-bda975b8-a346-4d8c-9570-bdba54191830.png">

<img width="1186" alt="スクリーンショット 2022-09-08 17 35 28" src="https://user-images.githubusercontent.com/86545986/189075737-e50f8815-3673-43c4-956d-8315630c2503.png">


<img width="854" alt="スクリーンショット 2022-09-08 17 35 39" src="https://user-images.githubusercontent.com/86545986/189075780-11adc904-b16b-4cab-bab4-b0b794351151.png">

